### PR TITLE
Auth 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ bin/
 *.iws
 *.iml
 *.ipr
+*.yml
 out/
 !**/src/main/**/out/
 !**/src/test/**/out/

--- a/build.gradle
+++ b/build.gradle
@@ -19,9 +19,40 @@ repositories {
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter'
+	// 기본 설정
+	implementation 'org.springframework.boot:spring-boot-starter-web'
+
+	// Jpa
+	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+
+	// 이메일 전송 부분
+	implementation 'org.springframework.boot:spring-boot-starter-mail'
+
+	// DB 의존성 추가
+	runtimeOnly 'com.h2database:h2'
+	developmentOnly 'org.springframework.boot:spring-boot-devtools'
+	implementation 'mysql:mysql-connector-java:8.0.33'
+
+	// lombok 추가
+	compileOnly 'org.projectlombok:lombok'
+	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+	// SpringSecurity 설정
+	implementation 'org.springframework.boot:spring-boot-starter-security'
+
+	// Jwt
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
+	// 유효성 검사
+	implementation 'jakarta.validation:jakarta.validation-api:3.0.2'
+	implementation 'org.hibernate.validator:hibernate-validator:8.0.0.Final'
+
+	// swagger 연결
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/louter/uhd/auth/controller/AuthController.java
+++ b/src/main/java/com/louter/uhd/auth/controller/AuthController.java
@@ -1,13 +1,16 @@
 package com.louter.uhd.auth.controller;
 
 import com.louter.uhd.auth.domain.User;
+import com.louter.uhd.auth.dto.request.LoginRequest;
 import com.louter.uhd.auth.dto.request.SendVerificationEmailRequest;
 import com.louter.uhd.auth.dto.request.SignupRequest;
 import com.louter.uhd.auth.dto.request.VerifyCodeRequest;
+import com.louter.uhd.auth.dto.response.LoginResponse;
 import com.louter.uhd.auth.dto.response.SendVerificationEmailResponse;
 import com.louter.uhd.auth.dto.response.SignupResponse;
 import com.louter.uhd.auth.dto.response.VerifyCodeResponse;
 import com.louter.uhd.auth.usecase.EmailUseCase;
+import com.louter.uhd.auth.usecase.LoginUseCase;
 import com.louter.uhd.auth.usecase.SignupUseCase;
 import jakarta.validation.constraints.Email;
 import lombok.RequiredArgsConstructor;
@@ -25,6 +28,8 @@ import java.util.Map;
 public class AuthController {
     // 회원가입
     private final SignupUseCase signupUseCase;
+    // 로그인
+    private final LoginUseCase loginUseCase;
     // 이메일
     private final EmailUseCase emailUseCase;
 
@@ -44,5 +49,11 @@ public class AuthController {
     public ResponseEntity<Object> signup(@RequestBody SignupRequest signupRequest) {
         User user = signupUseCase.signup(signupRequest);
         return ResponseEntity.ok(SignupResponse.from(user));
+    }
+
+    @PostMapping("/login")
+    public ResponseEntity<Object> login(@RequestBody LoginRequest loginRequest) {
+        Map<User, Object> response = loginUseCase.login(loginRequest);
+        return ResponseEntity.ok(LoginResponse.from(response));
     }
 }

--- a/src/main/java/com/louter/uhd/auth/controller/AuthController.java
+++ b/src/main/java/com/louter/uhd/auth/controller/AuthController.java
@@ -1,9 +1,13 @@
 package com.louter.uhd.auth.controller;
 
 import com.louter.uhd.auth.domain.User;
+import com.louter.uhd.auth.dto.request.SendVerificationEmailRequest;
 import com.louter.uhd.auth.dto.request.SignupRequest;
+import com.louter.uhd.auth.dto.response.SendVerificationEmailResponse;
 import com.louter.uhd.auth.dto.response.SignupResponse;
+import com.louter.uhd.auth.usecase.EmailUseCase;
 import com.louter.uhd.auth.usecase.SignupUseCase;
+import jakarta.validation.constraints.Email;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -11,11 +15,22 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.Map;
+
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/auth")
 public class AuthController {
+    // 회원가입
     private final SignupUseCase signupUseCase;
+    // 이메일
+    private final EmailUseCase emailUseCase;
+
+    @PostMapping("/email/send")
+    public ResponseEntity<Object> signupEmail(@RequestBody SendVerificationEmailRequest request) {
+        Map<User, String> response = emailUseCase.sendVerificationEmail(request);
+        return ResponseEntity.ok(SendVerificationEmailResponse.from(response));
+    }
 
     @PostMapping("/signup")
     public ResponseEntity<Object> signup(@RequestBody SignupRequest signupRequest) {

--- a/src/main/java/com/louter/uhd/auth/controller/AuthController.java
+++ b/src/main/java/com/louter/uhd/auth/controller/AuthController.java
@@ -3,8 +3,10 @@ package com.louter.uhd.auth.controller;
 import com.louter.uhd.auth.domain.User;
 import com.louter.uhd.auth.dto.request.SendVerificationEmailRequest;
 import com.louter.uhd.auth.dto.request.SignupRequest;
+import com.louter.uhd.auth.dto.request.VerifyCodeRequest;
 import com.louter.uhd.auth.dto.response.SendVerificationEmailResponse;
 import com.louter.uhd.auth.dto.response.SignupResponse;
+import com.louter.uhd.auth.dto.response.VerifyCodeResponse;
 import com.louter.uhd.auth.usecase.EmailUseCase;
 import com.louter.uhd.auth.usecase.SignupUseCase;
 import jakarta.validation.constraints.Email;
@@ -30,6 +32,12 @@ public class AuthController {
     public ResponseEntity<Object> signupEmail(@RequestBody SendVerificationEmailRequest request) {
         Map<User, String> response = emailUseCase.sendVerificationEmail(request);
         return ResponseEntity.ok(SendVerificationEmailResponse.from(response));
+    }
+
+    @PostMapping("/email/verify")
+    public ResponseEntity<Object> verifyCode(@RequestBody VerifyCodeRequest request) {
+        Map<User, String> response = emailUseCase.verifyCode(request);
+        return ResponseEntity.ok(VerifyCodeResponse.from(response));
     }
 
     @PostMapping("/signup")

--- a/src/main/java/com/louter/uhd/auth/controller/AuthController.java
+++ b/src/main/java/com/louter/uhd/auth/controller/AuthController.java
@@ -1,17 +1,12 @@
 package com.louter.uhd.auth.controller;
 
 import com.louter.uhd.auth.domain.User;
-import com.louter.uhd.auth.dto.request.LoginRequest;
-import com.louter.uhd.auth.dto.request.SendVerificationEmailRequest;
-import com.louter.uhd.auth.dto.request.SignupRequest;
-import com.louter.uhd.auth.dto.request.VerifyCodeRequest;
-import com.louter.uhd.auth.dto.response.LoginResponse;
-import com.louter.uhd.auth.dto.response.SendVerificationEmailResponse;
-import com.louter.uhd.auth.dto.response.SignupResponse;
-import com.louter.uhd.auth.dto.response.VerifyCodeResponse;
+import com.louter.uhd.auth.dto.request.*;
+import com.louter.uhd.auth.dto.response.*;
 import com.louter.uhd.auth.usecase.EmailUseCase;
 import com.louter.uhd.auth.usecase.LoginUseCase;
 import com.louter.uhd.auth.usecase.SignupUseCase;
+import com.louter.uhd.auth.usecase.UpdateUserInfoUseCase;
 import jakarta.validation.constraints.Email;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -32,6 +27,8 @@ public class AuthController {
     private final LoginUseCase loginUseCase;
     // 이메일
     private final EmailUseCase emailUseCase;
+    // 정보 수정
+    private final UpdateUserInfoUseCase updateUserInfoUseCase;
 
     @PostMapping("/email/send")
     public ResponseEntity<Object> signupEmail(@RequestBody SendVerificationEmailRequest request) {
@@ -55,5 +52,12 @@ public class AuthController {
     public ResponseEntity<Object> login(@RequestBody LoginRequest loginRequest) {
         Map<User, Object> response = loginUseCase.login(loginRequest);
         return ResponseEntity.ok(LoginResponse.from(response));
+    }
+
+    @PostMapping("/update/pw")
+    public ResponseEntity<Object> updateUserId(@RequestBody UpdatePwRequest updatePwRequest) {
+        // 비밀번호 변경
+        User user = updateUserInfoUseCase.updateUserPassword(updatePwRequest);
+        return ResponseEntity.ok(UpdatePwResponse.from(user));
     }
 }

--- a/src/main/java/com/louter/uhd/auth/controller/AuthController.java
+++ b/src/main/java/com/louter/uhd/auth/controller/AuthController.java
@@ -1,0 +1,25 @@
+package com.louter.uhd.auth.controller;
+
+import com.louter.uhd.auth.domain.User;
+import com.louter.uhd.auth.dto.request.SignupRequest;
+import com.louter.uhd.auth.dto.response.SignupResponse;
+import com.louter.uhd.auth.usecase.SignupUseCase;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/auth")
+public class AuthController {
+    private final SignupUseCase signupUseCase;
+
+    @PostMapping("/signup")
+    public ResponseEntity<Object> signup(@RequestBody SignupRequest signupRequest) {
+        User user = signupUseCase.signup(signupRequest);
+        return ResponseEntity.ok(SignupResponse.from(user));
+    }
+}

--- a/src/main/java/com/louter/uhd/auth/domain/User.java
+++ b/src/main/java/com/louter/uhd/auth/domain/User.java
@@ -1,0 +1,29 @@
+package com.louter.uhd.auth.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.*;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Table(name = "users")
+public class User {
+    @Id
+    @Column(name = "u_id", unique = true, nullable = false)
+    private String userId;
+
+    @Column(name = "u_password", nullable = false)
+    private String userPassword;
+
+    @Column(name = "u_name", nullable = false)
+    private String userName;
+
+    @Column(name = "u_email", unique = true, nullable = false)
+    private String userEmail;
+}

--- a/src/main/java/com/louter/uhd/auth/domain/VerificationPurpose.java
+++ b/src/main/java/com/louter/uhd/auth/domain/VerificationPurpose.java
@@ -1,0 +1,6 @@
+package com.louter.uhd.auth.domain;
+
+public enum VerificationPurpose {
+    SIGN_UP,
+    UPDATE_INFO
+}

--- a/src/main/java/com/louter/uhd/auth/dto/request/LoginRequest.java
+++ b/src/main/java/com/louter/uhd/auth/dto/request/LoginRequest.java
@@ -1,0 +1,14 @@
+package com.louter.uhd.auth.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class LoginRequest {
+    @NotNull
+    private String userId;
+    @NotNull
+    private String userPassword;
+}

--- a/src/main/java/com/louter/uhd/auth/dto/request/SendVerificationEmailRequest.java
+++ b/src/main/java/com/louter/uhd/auth/dto/request/SendVerificationEmailRequest.java
@@ -1,0 +1,15 @@
+package com.louter.uhd.auth.dto.request;
+
+import com.louter.uhd.auth.domain.VerificationPurpose;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class SendVerificationEmailRequest {
+    @NotNull
+    private String userEmail;
+    @NotNull
+    private VerificationPurpose purpose;
+}

--- a/src/main/java/com/louter/uhd/auth/dto/request/SignupRequest.java
+++ b/src/main/java/com/louter/uhd/auth/dto/request/SignupRequest.java
@@ -1,0 +1,18 @@
+package com.louter.uhd.auth.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class SignupRequest {
+    @NotNull
+    private String userId;
+    @NotNull
+    private String userPassword;
+    @NotNull
+    private String userName;
+    @NotNull
+    private String userEmail;
+}

--- a/src/main/java/com/louter/uhd/auth/dto/request/UpdatePwRequest.java
+++ b/src/main/java/com/louter/uhd/auth/dto/request/UpdatePwRequest.java
@@ -1,0 +1,14 @@
+package com.louter.uhd.auth.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class UpdatePwRequest {
+    @NotNull
+    private String userId;
+    @NotNull
+    private String userPassword;
+}

--- a/src/main/java/com/louter/uhd/auth/dto/request/VerifyCodeRequest.java
+++ b/src/main/java/com/louter/uhd/auth/dto/request/VerifyCodeRequest.java
@@ -1,0 +1,17 @@
+package com.louter.uhd.auth.dto.request;
+
+import com.louter.uhd.auth.domain.VerificationPurpose;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class VerifyCodeRequest {
+    @NotNull
+    private String userEmail;
+    @NotNull
+    private String code;
+    @NotNull
+    private VerificationPurpose purpose;
+}

--- a/src/main/java/com/louter/uhd/auth/dto/response/LoginResponse.java
+++ b/src/main/java/com/louter/uhd/auth/dto/response/LoginResponse.java
@@ -1,0 +1,33 @@
+package com.louter.uhd.auth.dto.response;
+
+import com.louter.uhd.auth.domain.User;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.Map;
+
+@Getter
+@Setter
+@Builder
+public class LoginResponse {
+    @NotNull
+    private Boolean success;
+    @NotNull
+    private String userId;
+    @NotNull
+    private String token;
+
+    public static LoginResponse from(Map<User, Object> response) {
+        Map.Entry<User, Object> entry = response.entrySet().iterator().next();
+        User user = entry.getKey();
+        String token = String.valueOf(entry.getValue());
+
+        return LoginResponse.builder()
+                .success(true)
+                .userId(user.getUserId())
+                .token(token)
+                .build();
+    }
+}

--- a/src/main/java/com/louter/uhd/auth/dto/response/SendVerificationEmailResponse.java
+++ b/src/main/java/com/louter/uhd/auth/dto/response/SendVerificationEmailResponse.java
@@ -1,0 +1,33 @@
+package com.louter.uhd.auth.dto.response;
+
+import com.louter.uhd.auth.domain.User;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.Map;
+
+@Getter
+@Setter
+@Builder
+public class SendVerificationEmailResponse {
+    @NotNull
+    private Boolean success;
+    @NotNull
+    private String userEmail;
+    @NotNull
+    private String code;
+
+    public static SendVerificationEmailResponse from(Map<User, String> response) {
+        Map.Entry<User, String> entry = response.entrySet().iterator().next();
+        User user = entry.getKey();
+        String code = entry.getValue();
+
+        return SendVerificationEmailResponse.builder()
+                .success(true)
+                .userEmail(user.getUserEmail())
+                .code(code)
+                .build();
+    }
+}

--- a/src/main/java/com/louter/uhd/auth/dto/response/SignupResponse.java
+++ b/src/main/java/com/louter/uhd/auth/dto/response/SignupResponse.java
@@ -1,0 +1,30 @@
+package com.louter.uhd.auth.dto.response;
+
+import com.louter.uhd.auth.domain.User;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+public class SignupResponse {
+    @NotNull
+    private Boolean success;
+    @NotNull
+    private String userId;
+    @NotNull
+    private String userName;
+    @NotNull
+    private String userEmail;
+
+    public static SignupResponse from(User user) {
+        return SignupResponse.builder()
+                .success(true)
+                .userId(user.getUserId())
+                .userName(user.getUserName())
+                .userEmail(user.getUserEmail())
+                .build();
+    }
+}

--- a/src/main/java/com/louter/uhd/auth/dto/response/UpdatePwResponse.java
+++ b/src/main/java/com/louter/uhd/auth/dto/response/UpdatePwResponse.java
@@ -1,0 +1,24 @@
+package com.louter.uhd.auth.dto.response;
+
+import com.louter.uhd.auth.domain.User;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+public class UpdatePwResponse {
+    @NotNull
+    private Boolean success;
+    @NotNull
+    private String userId;
+
+    public static UpdatePwResponse from(User user) {
+        return UpdatePwResponse.builder()
+                .success(true)
+                .userId(user.getUserId())
+                .build();
+    }
+}

--- a/src/main/java/com/louter/uhd/auth/dto/response/VerifyCodeResponse.java
+++ b/src/main/java/com/louter/uhd/auth/dto/response/VerifyCodeResponse.java
@@ -1,0 +1,33 @@
+package com.louter.uhd.auth.dto.response;
+
+import com.louter.uhd.auth.domain.User;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.Map;
+
+@Getter
+@Setter
+@Builder
+public class VerifyCodeResponse {
+    @NotNull
+    private Boolean success;
+    @NotNull
+    private String userEmail;
+    @NotNull
+    private String code;
+
+    public static VerifyCodeResponse from(Map<User, String> response) {
+        Map.Entry<User, String> entry = response.entrySet().iterator().next();
+        User user = entry.getKey();
+        String code = entry.getValue();
+
+        return VerifyCodeResponse.builder()
+                .success(true)
+                .userEmail(user.getUserEmail())
+                .code(code)
+                .build();
+    }
+}

--- a/src/main/java/com/louter/uhd/auth/exception/AlreadyUsingAccountException.java
+++ b/src/main/java/com/louter/uhd/auth/exception/AlreadyUsingAccountException.java
@@ -1,0 +1,7 @@
+package com.louter.uhd.auth.exception;
+
+public class AlreadyUsingAccountException extends AuthenticationException {
+    public AlreadyUsingAccountException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/louter/uhd/auth/exception/AuthenticationException.java
+++ b/src/main/java/com/louter/uhd/auth/exception/AuthenticationException.java
@@ -1,0 +1,7 @@
+package com.louter.uhd.auth.exception;
+
+public class AuthenticationException extends RuntimeException {
+    public AuthenticationException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/louter/uhd/auth/exception/IllegalArgsException.java
+++ b/src/main/java/com/louter/uhd/auth/exception/IllegalArgsException.java
@@ -1,0 +1,7 @@
+package com.louter.uhd.auth.exception;
+
+public class IllegalArgsException extends AuthenticationException {
+    public IllegalArgsException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/louter/uhd/auth/exception/TokenExpiredException.java
+++ b/src/main/java/com/louter/uhd/auth/exception/TokenExpiredException.java
@@ -1,0 +1,7 @@
+package com.louter.uhd.auth.exception;
+
+public class TokenExpiredException extends AuthenticationException {
+    public TokenExpiredException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/louter/uhd/auth/exception/UserNotFoundException.java
+++ b/src/main/java/com/louter/uhd/auth/exception/UserNotFoundException.java
@@ -1,0 +1,7 @@
+package com.louter.uhd.auth.exception;
+
+public class UserNotFoundException extends AuthenticationException {
+    public UserNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/louter/uhd/auth/exception/WrongVerifiedCodeException.java
+++ b/src/main/java/com/louter/uhd/auth/exception/WrongVerifiedCodeException.java
@@ -1,0 +1,7 @@
+package com.louter.uhd.auth.exception;
+
+public class WrongVerifiedCodeException extends AuthenticationException {
+    public WrongVerifiedCodeException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/louter/uhd/auth/handler/AuthExceptionHandler.java
+++ b/src/main/java/com/louter/uhd/auth/handler/AuthExceptionHandler.java
@@ -1,0 +1,60 @@
+package com.louter.uhd.auth.handler;
+
+import com.louter.uhd.auth.domain.User;
+import com.louter.uhd.auth.exception.AlreadyUsingAccountException;
+import com.louter.uhd.auth.exception.AuthenticationException;
+import com.louter.uhd.auth.exception.IllegalArgsException;
+import com.louter.uhd.auth.exception.UserNotFoundException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.Map;
+
+@RestControllerAdvice
+public class AuthExceptionHandler {
+    @ExceptionHandler(AlreadyUsingAccountException.class)
+    public ResponseEntity<Object> handleAlreadyUsingAccountException(AlreadyUsingAccountException e) {
+        return ResponseEntity
+                .status(HttpStatus.CONFLICT)
+                .body(Map.of(
+                        "success", false,
+                        "error_name", "AlreadyUsingAccountException",
+                        "message", e.getMessage()
+                ));
+    }
+
+    @ExceptionHandler(AuthenticationException.class)
+    public ResponseEntity<Object> handleAuthenticationException(AuthenticationException e) {
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(Map.of(
+                        "success", false,
+                        "error_name", "AuthenticationException",
+                        "message", e.getMessage()
+                ));
+    }
+
+    @ExceptionHandler(IllegalArgsException.class)
+    public ResponseEntity<Object> handleIllegalArgsException(IllegalArgsException e) {
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(Map.of(
+                        "success", false,
+                        "error_name", "IllegalArgsException",
+                        "message", e.getMessage()
+                ));
+    }
+
+    @ExceptionHandler(UserNotFoundException.class)
+    public ResponseEntity<Object> handleUserNotFoundException(UserNotFoundException e) {
+        return ResponseEntity
+                .status(HttpStatus.NOT_FOUND)
+                .body(Map.of(
+                        "success", false,
+                        "error_name", "UserNotFoundException",
+                        "message", e.getMessage()
+                ));
+    }
+}

--- a/src/main/java/com/louter/uhd/auth/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/louter/uhd/auth/jwt/JwtAuthenticationFilter.java
@@ -1,0 +1,40 @@
+package com.louter.uhd.auth.jwt;
+
+import com.louter.uhd.auth.exception.TokenExpiredException;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+
+public class JwtAuthenticationFilter extends JwtUtil {
+
+    public JwtAuthenticationFilter(String secretKey, Long expiration) {
+        super(secretKey, expiration);
+    }
+
+    // 이메일로 토큰 생성
+    public String userEmailFromToken(String token) {
+        Claims claims = Jwts.parserBuilder()
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+
+        return claims.getSubject();
+    }
+
+    // 토큰 만료 확인, 해당 클래스에서 자체적으로 호출해서, 추가적인 호출 필요 없음
+    public void validateToken(String token) {
+        try {
+            Jwts.parserBuilder()
+                    .setSigningKey(key)
+                    .build()
+                    .parseClaimsJws(token);
+
+        } catch (ExpiredJwtException e) {
+            throw new TokenExpiredException(e.getMessage());
+        } catch (JwtException | IllegalArgumentException e) {
+            throw new IllegalArgumentException(e.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/louter/uhd/auth/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/louter/uhd/auth/jwt/JwtAuthenticationFilter.java
@@ -12,8 +12,8 @@ public class JwtAuthenticationFilter extends JwtUtil {
         super(secretKey, expiration);
     }
 
-    // 이메일로 토큰 생성
-    public String userEmailFromToken(String token) {
+    // 아이디로 토큰 생성
+    public String userIdFromToken(String token) {
         Claims claims = Jwts.parserBuilder()
                 .setSigningKey(key)
                 .build()

--- a/src/main/java/com/louter/uhd/auth/jwt/JwtFilter.java
+++ b/src/main/java/com/louter/uhd/auth/jwt/JwtFilter.java
@@ -1,0 +1,59 @@
+package com.louter.uhd.auth.jwt;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.Collections;
+
+@Component
+@RequiredArgsConstructor
+public class JwtFilter extends OncePerRequestFilter {
+
+    private final JwtAuthenticationFilter jwtAuth;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        String path = request.getRequestURI();
+
+
+        // 필터 지정
+        if (path.equals("/favicon.ico") ||
+                path.startsWith("/.well-known/") ||
+                path.equals("/") ||
+                path.startsWith("/auth/") ||
+                path.startsWith("/email/") ||
+                path.startsWith("/swagger-ui/") ||
+                path.startsWith("/v3/api-docs/") ||
+                path.startsWith("/api-docs")) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        String authHeader = request.getHeader("Authorization");
+
+        if (authHeader != null && authHeader.startsWith("Bearer ")) {
+            String token = authHeader.substring(7);
+            try {
+                jwtAuth.validateToken(token);
+                String userEmail = jwtAuth.userEmailFromToken(token);
+                Authentication authentication = new UsernamePasswordAuthenticationToken(userEmail, null, Collections.emptyList());
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+            } catch (Exception e) {
+                response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+                response.getWriter().write("Invalid JWT token");
+                return;
+            }
+        }
+
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/java/com/louter/uhd/auth/jwt/JwtFilter.java
+++ b/src/main/java/com/louter/uhd/auth/jwt/JwtFilter.java
@@ -44,8 +44,8 @@ public class JwtFilter extends OncePerRequestFilter {
             String token = authHeader.substring(7);
             try {
                 jwtAuth.validateToken(token);
-                String userEmail = jwtAuth.userEmailFromToken(token);
-                Authentication authentication = new UsernamePasswordAuthenticationToken(userEmail, null, Collections.emptyList());
+                String userId = jwtAuth.userIdFromToken(token);
+                Authentication authentication = new UsernamePasswordAuthenticationToken(userId, null, Collections.emptyList());
                 SecurityContextHolder.getContext().setAuthentication(authentication);
             } catch (Exception e) {
                 response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);

--- a/src/main/java/com/louter/uhd/auth/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/louter/uhd/auth/jwt/JwtTokenProvider.java
@@ -1,0 +1,26 @@
+package com.louter.uhd.auth.jwt;
+
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+
+import java.util.Date;
+
+public class JwtTokenProvider extends JwtUtil {
+
+    public JwtTokenProvider(String secretKey, Long expiration) {
+        super(secretKey, expiration);
+    }
+
+    // 토큰 생성
+    public String generateToken(String userEmail) {
+        Date now = new Date();
+        Date expiryDate = new Date(now.getTime() + expiration);
+
+        return Jwts.builder()
+                .setSubject(userEmail)
+                .setIssuedAt(now)
+                .setExpiration(expiryDate)
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+    }
+}

--- a/src/main/java/com/louter/uhd/auth/jwt/JwtUtil.java
+++ b/src/main/java/com/louter/uhd/auth/jwt/JwtUtil.java
@@ -1,0 +1,16 @@
+package com.louter.uhd.auth.jwt;
+
+import io.jsonwebtoken.security.Keys;
+
+import java.security.Key;
+
+public class JwtUtil {
+
+    protected final Key key;
+    protected final Long expiration;
+
+    public JwtUtil(String secretKey, Long expiration) {
+        this.key = Keys.hmacShaKeyFor(secretKey.getBytes());
+        this.expiration = expiration;
+    }
+}

--- a/src/main/java/com/louter/uhd/auth/repository/UserRepository.java
+++ b/src/main/java/com/louter/uhd/auth/repository/UserRepository.java
@@ -1,0 +1,10 @@
+package com.louter.uhd.auth.repository;
+
+import com.louter.uhd.auth.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface UserRepository extends JpaRepository<User, Long> {
+
+}

--- a/src/main/java/com/louter/uhd/auth/repository/UserRepository.java
+++ b/src/main/java/com/louter/uhd/auth/repository/UserRepository.java
@@ -1,10 +1,28 @@
 package com.louter.uhd.auth.repository;
 
 import com.louter.uhd.auth.domain.User;
+import jakarta.transaction.Transactional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
 
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
+    // 유저 조회 함수
+    Optional<User> findByUserId(String userId);
+    Optional<User> findByUserEmail(String userEmail);
 
+    // 유저 존재 확인 함수
+    boolean existsByUserId(String userId);
+    boolean existsByUserEmail(String userEmail);
+
+    // 비번 수정
+    @Transactional
+    @Modifying
+    @Query("UPDATE User user SET user.userPassword = :newPassword WHERE user.userId = :userId")
+    void updateUserPassword(@Param("userId") String id, @Param("newPassword") String newPassword);
 }

--- a/src/main/java/com/louter/uhd/auth/usecase/EmailUseCase.java
+++ b/src/main/java/com/louter/uhd/auth/usecase/EmailUseCase.java
@@ -1,0 +1,80 @@
+package com.louter.uhd.auth.usecase;
+
+import com.louter.uhd.auth.domain.User;
+import com.louter.uhd.auth.domain.VerificationPurpose;
+import com.louter.uhd.auth.dto.request.SendVerificationEmailRequest;
+import com.louter.uhd.auth.exception.UserNotFoundException;
+import com.louter.uhd.auth.repository.UserRepository;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Random;
+
+@Service
+@RequiredArgsConstructor
+public class EmailUseCase {
+    // 이메일 전송용
+    private final JavaMailSender mailSender;
+    // 이메일-인증코드 저장용
+    private final Map<String, Map<VerificationPurpose, CodeInfo>> codeMap = new HashMap<>();
+    // 예외 호출
+    private final ValidationUseCase validationUseCase;
+    private final UserRepository userRepository;
+
+    // 인증 코드 생성
+    private String generateCode() {
+        return String.format("%06d", new Random().nextInt(1000000));
+    }
+
+    // 인증 코드 전송
+    public Map<User, String> sendVerificationEmail(SendVerificationEmailRequest emailRequest) {
+        validationUseCase.checkUserEmail(emailRequest.getUserEmail());
+
+        String code = generateCode();
+        // 이메일 - (목적 - 코드) 저장
+        codeMap.computeIfAbsent(emailRequest.getUserEmail(), k -> new HashMap<>())
+                .put(emailRequest.getPurpose(), new CodeInfo(code));
+
+        SimpleMailMessage message = new SimpleMailMessage();
+
+        // purpose에 따라 메세지를 다르게 전송 가능하도록 구성
+        message.setTo(emailRequest.getUserEmail());
+        message.setSubject("[이메일 인증 코드]");
+        message.setText("Uhd 인증코드: " + code);
+
+        mailSender.send(message);
+
+        Optional<User> optionalUser  = userRepository.findByUserEmail(emailRequest.getUserEmail());
+        if (optionalUser.isEmpty()) {
+            throw new UserNotFoundException("유저가 조회되지 않음");
+        }
+
+        User user = optionalUser.get();
+
+        return Map.of(user, code);
+    }
+
+    // 만료시간 저장
+    private static final Map<VerificationPurpose, Long> EXPIRATION_MINUTES = Map.of(
+            VerificationPurpose.SIGN_UP, 10L,
+            VerificationPurpose.UPDATE_INFO, 5L
+    );
+
+    @Getter
+    private static class CodeInfo {
+        private final String code;
+        private final LocalDateTime createdAt;
+
+        public CodeInfo(String code) {
+            this.code = code;
+            this.createdAt = LocalDateTime.now();
+        }
+    }
+}

--- a/src/main/java/com/louter/uhd/auth/usecase/EmailUseCase.java
+++ b/src/main/java/com/louter/uhd/auth/usecase/EmailUseCase.java
@@ -3,7 +3,9 @@ package com.louter.uhd.auth.usecase;
 import com.louter.uhd.auth.domain.User;
 import com.louter.uhd.auth.domain.VerificationPurpose;
 import com.louter.uhd.auth.dto.request.SendVerificationEmailRequest;
+import com.louter.uhd.auth.dto.request.VerifyCodeRequest;
 import com.louter.uhd.auth.exception.UserNotFoundException;
+import com.louter.uhd.auth.exception.WrongVerifiedCodeException;
 import com.louter.uhd.auth.repository.UserRepository;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -11,6 +13,7 @@ import org.springframework.mail.SimpleMailMessage;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.stereotype.Service;
 
+import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.HashMap;
 import java.util.Map;
@@ -66,6 +69,42 @@ public class EmailUseCase {
             VerificationPurpose.SIGN_UP, 10L,
             VerificationPurpose.UPDATE_INFO, 5L
     );
+
+    // 인증 코드 검증
+    public Map<User, String> verifyCode(VerifyCodeRequest verifyCodeRequest) {
+        // 보낸 인증 코드 저장
+        CodeInfo userCode = codeMap.get(verifyCodeRequest.getUserEmail()).get(verifyCodeRequest.getPurpose());
+
+        // 정보가 존재하는지 확인
+        if (userCode == null) {
+            throw new WrongVerifiedCodeException("존재하지 않는 정보");
+        }
+
+        long expiration = EXPIRATION_MINUTES.get(verifyCodeRequest.getPurpose());
+
+        // 코드 만료 확인
+        if (Duration.between(userCode.getCreatedAt(), LocalDateTime.now()).toMinutes() >= expiration) {
+            // 코드 지움
+            codeMap.remove(verifyCodeRequest.getUserEmail());
+            throw new WrongVerifiedCodeException("만료된 인증 코드");
+        }
+
+        // 코드 일치 확인
+        if (verifyCodeRequest.getCode() == userCode.getCode()) {
+            System.out.println(verifyCodeRequest.getCode());
+            System.out.println(userCode.getCode());
+            throw new WrongVerifiedCodeException("잘못된 인증 코드");
+        }
+
+        Optional<User> optionalUser = userRepository.findByUserEmail(verifyCodeRequest.getUserEmail());
+        if (optionalUser.isEmpty()) {
+            throw new UserNotFoundException("유저가 조회 되지 않음");
+        }
+
+        User user = optionalUser.get();
+
+        return Map.of(user, verifyCodeRequest.getCode());
+    }
 
     @Getter
     private static class CodeInfo {

--- a/src/main/java/com/louter/uhd/auth/usecase/LoginUseCase.java
+++ b/src/main/java/com/louter/uhd/auth/usecase/LoginUseCase.java
@@ -1,0 +1,54 @@
+package com.louter.uhd.auth.usecase;
+
+import com.louter.uhd.auth.domain.User;
+import com.louter.uhd.auth.dto.request.LoginRequest;
+import com.louter.uhd.auth.exception.UserNotFoundException;
+import com.louter.uhd.auth.jwt.JwtTokenProvider;
+import com.louter.uhd.auth.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+import java.util.Map;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class LoginUseCase {
+    // 디비 접근
+    private final UserRepository userRepository;
+    // 예외 이용
+    private final ValidationUseCase validationUseCase;
+    // 비밀번호 암호화
+    private final PasswordEncoder passwordEncoder;
+    // Jwt 토큰 생성
+    private final JwtTokenProvider jwtTokenProvider;
+
+    // 로그인, 토큰 반환
+    public Map<User, Object> login(LoginRequest loginRequest) {
+        // 기본 예외 확인
+        validationUseCase.checkNull(loginRequest);
+
+        String userId = loginRequest.getUserId();
+        String userPassword = loginRequest.getUserPassword();
+
+        validationUseCase.checkUserId(userId);
+        validationUseCase.checkUserPassword(userPassword);
+
+        Optional<User> optionalUser = userRepository.findByUserId(userId);
+
+        // 유저 조회
+        if (optionalUser.isEmpty()) {
+            throw new UserNotFoundException("유저가 조회되지 않음");
+        }
+
+        User user = optionalUser.get();
+
+        if (!passwordEncoder.matches(userPassword, user.getUserPassword())) {
+            throw new UserNotFoundException("유저 조회 실패");
+        }
+
+        // 토큰 생성 및 반환
+        return Map.of(user, jwtTokenProvider.generateToken(String.valueOf(user.getUserId())));
+    }
+}

--- a/src/main/java/com/louter/uhd/auth/usecase/SignupUseCase.java
+++ b/src/main/java/com/louter/uhd/auth/usecase/SignupUseCase.java
@@ -1,0 +1,48 @@
+package com.louter.uhd.auth.usecase;
+
+import com.louter.uhd.auth.domain.User;
+import com.louter.uhd.auth.dto.request.SignupRequest;
+import com.louter.uhd.auth.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class SignupUseCase {
+    // 디비 접근
+    private final UserRepository userRepository;
+    // 예외 호출
+    private final ValidationUseCase validationUseCase;
+    // 비밀번호 암호화
+    private final PasswordEncoder passwordEncoder;
+
+    // 회원가입
+    public User signup(SignupRequest signupRequest) {
+        // 기본 예외 처리
+        validationUseCase.checkNull(signupRequest);
+
+        String userEmail = signupRequest.getUserEmail();
+        String userId = signupRequest.getUserId();
+        String userPassword = signupRequest.getUserPassword();
+        String userName = signupRequest.getUserName();
+
+        validationUseCase.checkUserEmail(userEmail);
+        validationUseCase.checkUserId(userId);
+        validationUseCase.checkUserPassword(userPassword);
+        validationUseCase.checkUserName(userName);
+
+        validationUseCase.checkExistAccount(userEmail, userId);
+
+        // 유저 생성
+        User user = User.builder()
+                .userEmail(userEmail)
+                .userId(userId)
+                .userPassword(passwordEncoder.encode(userPassword))
+                .userName(userName)
+                .build();
+
+        // 유저 등록
+        return userRepository.save(user);
+    }
+}

--- a/src/main/java/com/louter/uhd/auth/usecase/UpdateUserInfoUseCase.java
+++ b/src/main/java/com/louter/uhd/auth/usecase/UpdateUserInfoUseCase.java
@@ -1,0 +1,42 @@
+package com.louter.uhd.auth.usecase;
+
+import com.louter.uhd.auth.domain.User;
+import com.louter.uhd.auth.dto.request.UpdatePwRequest;
+import com.louter.uhd.auth.exception.UserNotFoundException;
+import com.louter.uhd.auth.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class UpdateUserInfoUseCase {
+    // 디비 접근
+    private final UserRepository userRepository;
+    // 비밀번호 암호화
+    private final PasswordEncoder passwordEncoder;
+    // 예외 분리
+    private final ValidationUseCase validationUseCase;
+
+    public User updateUserPassword(UpdatePwRequest updatePwRequest) {
+        String userPassword = updatePwRequest.getUserPassword();
+        String userId = updatePwRequest.getUserId();
+
+        validationUseCase.checkNull(userId);
+        validationUseCase.checkUserId(userId);
+
+        Optional<User> optionalUser = userRepository.findByUserId(userId);
+        User user = optionalUser.orElseThrow(() ->
+                new UserNotFoundException("이메일이 조회되지 않음"));
+
+        validationUseCase.checkNull(userPassword);
+        validationUseCase.checkUserPassword(userPassword);
+
+        // 디비 수정
+        userRepository.updateUserPassword(userId, passwordEncoder.encode(userPassword));
+
+        return user;
+    }
+}

--- a/src/main/java/com/louter/uhd/auth/usecase/ValidationUseCase.java
+++ b/src/main/java/com/louter/uhd/auth/usecase/ValidationUseCase.java
@@ -1,8 +1,99 @@
 package com.louter.uhd.auth.usecase;
 
+import com.louter.uhd.auth.dto.request.SignupRequest;
+import com.louter.uhd.auth.exception.AlreadyUsingAccountException;
+import com.louter.uhd.auth.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 @Service
+@RequiredArgsConstructor
 public class ValidationUseCase {
+    // 디비 접근
+    private final UserRepository userRepository;
 
+    // 널 값 확인 - 한 요소
+    public <T> void checkNull(T element) {
+        if (element == null || element.toString().trim().isEmpty()) {
+            throw new IllegalArgumentException("빈 값이 존재");
+        }
+    }
+
+    // 널 값 확인 - 회원가입
+    public void checkNull(SignupRequest signupRequest) {
+        String userEmail = signupRequest.getUserEmail();
+        String userId = signupRequest.getUserId();
+        String userPassword = signupRequest.getUserPassword();
+        String userName = signupRequest.getUserName();
+
+        if (userEmail.isEmpty() || userId.isEmpty() || userPassword.isEmpty() || userName.isEmpty()) {
+            throw new IllegalArgumentException("빈 값이 존재");
+        }
+    }
+
+    // 아이디 확인
+    public void checkUserId(String userId) {
+        if (userId.length() < 4 || userId.length() > 20) {
+            throw new IllegalArgumentException("길이가 잘못됨");
+        }
+        if (!userId.matches("^[a-zA-Z0-9]+$")) {
+            throw new IllegalArgumentException("영어, 숫자 이외의 글자");
+        }
+        if (userId.matches(".*(.)\\1{2,}.*")) {
+            throw new IllegalArgumentException("3글자 이상 연속");
+        }
+        if (!userId.matches("^(?=.*[A-Za-z])(?=.*\\d).+$")) {
+            throw new IllegalArgumentException("영어, 숫자 포함 안 됨");
+        }
+    }
+
+    // 비밀번호 확인
+    public void checkUserPassword(String userPassword) {
+        if (userPassword.length() < 6 || userPassword.length() > 20) {
+            throw new IllegalArgumentException("길이가 잘못됨");
+        }
+        if (!userPassword.matches("^[A-Za-z0-9@$!%*?&]+$")) {
+            throw new IllegalArgumentException("영어, 숫자, 특수문자 이외의 글자");
+        }
+        if (userPassword.matches(".*(.)\\1{2,}.*")) {
+            throw new IllegalArgumentException("3글자 이상 연속");
+        }
+        if (!userPassword.matches("^(?=.*[A-Za-z])(?=.*\\d)(?=.*[@$!%*?&]).+$")) {
+            throw new IllegalArgumentException("영어, 숫자, 특수문자를 포함 안 됨");
+        }
+    }
+
+    // 이메일 확인
+    public void checkUserEmail(String userEmail) {
+        if (!userEmail.matches("^[A-Za-z0-9+_.-]+@[A-Za-z0-9.-]+$")) {
+            throw new IllegalArgumentException("이메일 오류");
+        }
+    }
+
+    // 이름 확인
+    public void checkUserName(String userName) {
+        if (userName.length() < 1 || userName.length() > 20) {
+            throw new IllegalArgumentException("이름 오류");
+        }
+    }
+
+    // 존재하는지 확인
+    public void checkExistAccount(String userEmail, String userId) {
+        if (userRepository.existsByUserEmail(userEmail) ||
+                userRepository.existsByUserId(userId)) {
+            throw new AlreadyUsingAccountException("이미 존재함");
+        }
+    }
+
+    public void checkExistAccountByUserEmail(String userEmail) {
+        if (userRepository.existsByUserEmail(userEmail)) {
+            throw new AlreadyUsingAccountException("이미 존재함");
+        }
+    }
+
+    public void checkExistAccountByUserId(String userId) {
+        if (userRepository.existsByUserId(userId)) {
+            throw new AlreadyUsingAccountException("이미 존재함");
+        }
+    }
 }

--- a/src/main/java/com/louter/uhd/auth/usecase/ValidationUseCase.java
+++ b/src/main/java/com/louter/uhd/auth/usecase/ValidationUseCase.java
@@ -1,0 +1,8 @@
+package com.louter.uhd.auth.usecase;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class ValidationUseCase {
+
+}

--- a/src/main/java/com/louter/uhd/config/JwtConfig.java
+++ b/src/main/java/com/louter/uhd/config/JwtConfig.java
@@ -1,0 +1,40 @@
+package com.louter.uhd.config;
+
+import com.louter.uhd.auth.jwt.JwtAuthenticationFilter;
+import com.louter.uhd.auth.jwt.JwtFilter;
+import com.louter.uhd.auth.jwt.JwtTokenProvider;
+import com.louter.uhd.auth.jwt.JwtUtil;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ConfigurationProperties(prefix = "jwt")
+@Getter
+@Setter
+public class JwtConfig {
+    private String secret;
+    private Long expiration;
+
+    @Bean
+    public JwtUtil jwtUtil() {
+        return new JwtUtil(secret, expiration);
+    }
+
+    @Bean
+    public JwtAuthenticationFilter jwtAuthenticationFilter() {
+        return new JwtAuthenticationFilter(secret, expiration);
+    }
+
+    @Bean
+    public JwtTokenProvider jwtTokenProvider() {
+        return new JwtTokenProvider(secret, expiration);
+    }
+
+    @Bean
+    public JwtFilter jwtFilter() {
+        return new JwtFilter(jwtAuthenticationFilter());
+    }
+}

--- a/src/main/java/com/louter/uhd/config/SecurityConfig.java
+++ b/src/main/java/com/louter/uhd/config/SecurityConfig.java
@@ -1,5 +1,6 @@
 package com.louter.uhd.config;
 
+import com.louter.uhd.auth.jwt.JwtFilter;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
@@ -10,11 +11,15 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
 @EnableWebSecurity
 @RequiredArgsConstructor
 public class SecurityConfig {
+    // jwt
+    private final JwtFilter jwtFilter;
+
     // 생성자 DI
     @Bean
     public PasswordEncoder passwordEncoder() {
@@ -45,7 +50,8 @@ public class SecurityConfig {
                             response.setContentType("application/json"); // Content-Type 추가
                             response.getWriter().write("{\"error\": \"Unauthorized\", \"message\": \"Authentication required\"}");
                         })
-                );
+                )
+                .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
     }

--- a/src/main/java/com/louter/uhd/config/SecurityConfig.java
+++ b/src/main/java/com/louter/uhd/config/SecurityConfig.java
@@ -7,12 +7,19 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 
 @Configuration
 @EnableWebSecurity
 @RequiredArgsConstructor
 public class SecurityConfig {
+    // 생성자 DI
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
     // SpringSecutiry 세팅
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {

--- a/src/main/java/com/louter/uhd/config/SecurityConfig.java
+++ b/src/main/java/com/louter/uhd/config/SecurityConfig.java
@@ -1,0 +1,44 @@
+package com.louter.uhd.config;
+
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+    // SpringSecutiry 세팅
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(csrf -> csrf.disable())
+                .formLogin(form -> form.disable())
+                .httpBasic(httpBasic -> httpBasic.disable())
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/favicon.ico").permitAll()
+                        // 기본 경로
+                        .requestMatchers("/", "/auth/**").permitAll()
+                        // 스웨거
+                        .requestMatchers("/swagger-ui/**", "/v3/api-docs/**", "/api-docs").permitAll()
+                        .anyRequest().authenticated()
+                )
+                .sessionManagement(session ->
+                        session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+                )
+                .exceptionHandling(ex ->
+                        ex.authenticationEntryPoint((request, response, authException) -> {
+                            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+                            response.setContentType("application/json"); // Content-Type 추가
+                            response.getWriter().write("{\"error\": \"Unauthorized\", \"message\": \"Authentication required\"}");
+                        })
+                );
+
+        return http.build();
+    }
+}

--- a/src/main/java/com/louter/uhd/config/SecurityConfig.java
+++ b/src/main/java/com/louter/uhd/config/SecurityConfig.java
@@ -16,6 +16,7 @@ import org.springframework.security.web.SecurityFilterChain;
 @RequiredArgsConstructor
 public class SecurityConfig {
     // 생성자 DI
+    @Bean
     public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
     }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=uhd


### PR DESCRIPTION
## 작업 내용
1. 회원가입 구현
    - 물리 디비 구축 후 단순 회원가입 구현
    - 이메일 인증 이후 작동 되게 구성
    - 비밀번호 암호화
3. 로그인 구현
    - Jwt를 이용한 토큰 만료 방식 이용
    - 토큰 만료 구현
5. 이메일 인증 구현
    - JavaMailSender를 이용하여 구현
    - smtp 프로토콜로 통신하여 구현
    - VerifyPurpose 구성으로 회원가입과 정보 수정에 둘 다 사용가능하게 구현
       -> 코드 재사용성 높임
7. 비밀번호 변경 구현
    - 아이디를 통해 유저 조회 필터 구현
    - 이메일 인증 이후 작동 되게 구성
    - 비밀번호 암호화

## 앞으로 해야할 것
1. 게시글 CRUD 구현
2. 기타 정보 수정 기능 추가